### PR TITLE
Add ramMax to cbioportal CWL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,48 +2,20 @@
 
 **P**ost-processing & **L**ightweight **U**pdates **T**o pipeline **O**utput
 
-CWL files and workflows to accompany the *pluto* repo (in development)
+CWL files and workflows to accompany the [helix_filters_01](https://github.com/mskcc/helix_filters_01) repo.
 
-## Usage
+## Test Suite
 
-The main workflows can be run from the included `Makefile`. These recipes are set up for usage on MSKCC `juno` and `silo` servers and might need some modification for usage elsewhere.
+Development and testing takes place via the test suite.
 
-First, clone this repo;
-
-```
-git clone https://github.com/mskcc/pluto-cwl.git
-cd pluto-cwl
-```
-
-The most recent instructions can be seen with
-
-```
-make help
-```
-
-The main workflow can be run against a test dataset saved on the `juno` server with the command
-
-```
-make run
-```
-
-Extra arguments can be supplied to direct the workflow to run against other datasets (see `Makefile` for details), example;
-
-```
-make run \
-PROJ_ID=My_Project \
-TARGETS_LIST=/path/to/targest.ilist \
-DATA_DIR=/path/to/pipeline_data/
-```
-
-Depending on your user account settings on `juno` you might need to pull a copy of the needed Singularity containers manually before running;
+Make sure that you have copies of the Singularity containers used cached locally
 
 ```
 make singularity-pull
+make singularity-pull-dev
 make singularity-pull-facets
 ```
 
-## Run the Test Suite
 
 The included test suite can be run with:
 
@@ -51,8 +23,39 @@ The included test suite can be run with:
 make test
 ```
 
+It typically takes about 45 minutes to run all included tests
+
 - NOTE: tests require data sets that are pre-saved on the `juno` server
 
-## Related
+### Parallel Test Suite
 
-`pluto-cwl` is a migration of the CWL workflows that were originally included with the `helix_filters_01` repository; https://github.com/mskcc/helix_filters_01
+An extra recipe is included which can run the tests in parallel, for example to run 8 tests at once you can use this command:
+
+```
+make test3 -j 8
+```
+
+### Single Test
+
+For development purposes, it is helpful to be able to run only a specific test case, or subset of tests. 
+
+To do this, first enter an interactive bash session with the environment populated;
+
+```
+make bash
+```
+
+The run the script with the tests you are interested in, such as;
+
+```
+python tests/test_workflow_cwl.py
+```
+
+You can further select which test case(s) from the script you wish to run by adding their labels as args;
+
+```
+python tests/test_workflow_cwl.py TestClassName
+
+python tests/test_workflow_cwl.py TestClassName.test_function
+```
+


### PR DESCRIPTION
LSF was killing these jobs; it looks like this one tool can hit the 8 GB limit.

We should plan for this better (i.e., my "fix" is really just a workaround) - perhaps add a limiter to the wrapper script this tool is invoking - but since this is the first time this has happened, this bump from 8 GB to 16 GB should be ok for now.

I branched off of `master`; it looks like `dev` didn't get the updated README commit, that's why it's included in this PR.