### PR TITLE
Fix for handling handle empty vcf and maf

### DIFF
--- a/cwl/fillout_maf2vcf.cwl
+++ b/cwl/fillout_maf2vcf.cwl
@@ -26,9 +26,9 @@ requirements:
         vcf_sorted_gz="${ return inputs.sample_id + '.sorted.vcf.gz' }"
         sample_id="${ return inputs.sample_id }"
         # convert maf to vcf
-        num_lines="\$(wc -l < \${input_maf})"
-        more_than_five="\$(( \${num_lines} > 5))"
-        if [ "\${more_than_five}" == "1" ]
+        num_lines="\$(grep -v '^[#]' \${input_maf} | wc -l)"
+        more_than_one="\$(( \${num_lines} > 1))"
+        if [ "\${more_than_one}" == "1" ]
         then
           maf2vcf.pl --output-dir . --input-maf "\${input_maf}" --output-vcf "\${vcf}" --ref-fasta "\${fasta}"
         else

--- a/cwl/fillout_maf2vcf.cwl
+++ b/cwl/fillout_maf2vcf.cwl
@@ -26,7 +26,7 @@ requirements:
         vcf_sorted_gz="${ return inputs.sample_id + '.sorted.vcf.gz' }"
         sample_id="${ return inputs.sample_id }"
         # convert maf to vcf
-        num_lines=num_lines="\$(wc -l < \${input_maf})"
+        num_lines="\$(wc -l < \${input_maf})"
         more_than_five="\$(( \${num_lines} > 5))"
         if [ "\${more_than_five}" == "1" ]
         then

--- a/cwl/samples_fillout_workflow.cwl
+++ b/cwl/samples_fillout_workflow.cwl
@@ -133,6 +133,7 @@ steps:
                   var args2 = args1.map( (a) => "--bam " + a )
                   return args2.join(" ") ;
                   }'
+                sample_ids="${ return inputs.sample_ids.join("\t"); }"
                 fasta="${ return inputs.ref_fasta.path; }"
                 vcf="${ return inputs.targets_vcf.path }"
                 fillout_vcf="fillout.vcf"
@@ -157,7 +158,7 @@ steps:
                 ##FORMAT=<ID=DPF,Number=1,Type=Integer,Description="Total fragment depth">
                 ##FORMAT=<ID=RDF,Number=1,Type=Float,Description="Fragment depth matching reference (REF) allele">
                 ##FORMAT=<ID=ADF,Number=1,Type=Float,Description="Fragment depth matching alternate (ALT) allele">
-                #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  P-\${sample_id}       \${sample_id}
+                #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  P-\${sample_ids}
                 EOF
                 fi
       inputs:

--- a/cwl/samples_fillout_workflow.cwl
+++ b/cwl/samples_fillout_workflow.cwl
@@ -136,7 +136,30 @@ steps:
                 fasta="${ return inputs.ref_fasta.path; }"
                 vcf="${ return inputs.targets_vcf.path }"
                 fillout_vcf="fillout.vcf"
-                GetBaseCountsMultiSample --fasta "\${fasta}" --vcf "\${vcf}" --maq 20 --baq 20 --filter_improper_pair 0 --thread 8 --output "\${fillout_vcf}" \${bams_arg}
+                num_lines="\$(grep -v '^[#]' \${input_maf} | wc -l)"
+                more_than_zero="\$(( \${num_lines} > 0))"
+                if [ "\${more_than_zero}" == "1" ]
+                then
+                  GetBaseCountsMultiSample --fasta "\${fasta}" --vcf "\${vcf}" --maq 20 --baq 20 --filter_improper_pair 0 --thread 8 --output "\${fillout_vcf}" \${bams_arg}
+                else
+                  cat << EOF > "\${fillout_vcf}"
+                ##fileformat=VCFv4.2
+                ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Total depth">
+                ##FORMAT=<ID=RD,Number=1,Type=Integer,Description="Depth matching reference (REF) allele">
+                ##FORMAT=<ID=AD,Number=1,Type=Integer,Description="Depth matching alternate (ALT) allele">
+                ##FORMAT=<ID=VF,Number=1,Type=Float,Description="Variant frequence (AD/DP)">
+                ##FORMAT=<ID=DPP,Number=1,Type=Integer,Description="Depth on postitive strand">
+                ##FORMAT=<ID=DPN,Number=1,Type=Integer,Description="Depth on negative strand">
+                ##FORMAT=<ID=RDP,Number=1,Type=Integer,Description="Reference depth on postitive strand">
+                ##FORMAT=<ID=RDN,Number=1,Type=Integer,Description="Reference depth on negative strand">
+                ##FORMAT=<ID=ADP,Number=1,Type=Integer,Description="Alternate depth on postitive strand">
+                ##FORMAT=<ID=ADN,Number=1,Type=Integer,Description="Alternate depth on negative strand">
+                ##FORMAT=<ID=DPF,Number=1,Type=Integer,Description="Total fragment depth">
+                ##FORMAT=<ID=RDF,Number=1,Type=Float,Description="Fragment depth matching reference (REF) allele">
+                ##FORMAT=<ID=ADF,Number=1,Type=Float,Description="Fragment depth matching alternate (ALT) allele">
+                #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  P-\${sample_id}       \${sample_id}
+                EOF
+                fi
       inputs:
         sample_ids: string[]
         ref_fasta:

--- a/cwl/samples_fillout_workflow.cwl
+++ b/cwl/samples_fillout_workflow.cwl
@@ -137,7 +137,7 @@ steps:
                 fasta="${ return inputs.ref_fasta.path; }"
                 vcf="${ return inputs.targets_vcf.path }"
                 fillout_vcf="fillout.vcf"
-                num_lines="\$(grep -v '^[#]' \${input_maf} | wc -l)"
+                num_lines="\$(grep -v '^[#]' \${vcf} | wc -l)"
                 more_than_zero="\$(( \${num_lines} > 0))"
                 if [ "\${more_than_zero}" == "1" ]
                 then

--- a/cwl/samples_fillout_workflow.cwl
+++ b/cwl/samples_fillout_workflow.cwl
@@ -133,7 +133,12 @@ steps:
                   var args2 = args1.map( (a) => "--bam " + a )
                   return args2.join(" ") ;
                   }'
-                sample_ids="${ return inputs.sample_ids.join("\t"); }"
+                header_line='${
+                  var headers = ["CHROM","POS","ID","REF","ALT","QUAL","FILTER","INFO","FORMAT"]
+                  var sample_ids = inputs.sample_ids
+                  var header_list = headers.concat(sample_ids)
+                  return header_list.join("\t");
+                }'
                 fasta="${ return inputs.ref_fasta.path; }"
                 vcf="${ return inputs.targets_vcf.path }"
                 fillout_vcf="fillout.vcf"
@@ -158,7 +163,7 @@ steps:
                 ##FORMAT=<ID=DPF,Number=1,Type=Integer,Description="Total fragment depth">
                 ##FORMAT=<ID=RDF,Number=1,Type=Float,Description="Fragment depth matching reference (REF) allele">
                 ##FORMAT=<ID=ADF,Number=1,Type=Float,Description="Fragment depth matching alternate (ALT) allele">
-                #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  P-\${sample_ids}
+                #\${header_line}
                 EOF
                 fi
       inputs:


### PR DESCRIPTION
- Prevent gbcms from failing due to an empty vcf
- Fixed logic for detecting empty mafs that works on both research and clinical mafs